### PR TITLE
README: One more missing `/src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go install github.com/nabaz-io/nabaz/cmd/nabaz@latest
 
 # go test support
 mkdir -p $GOPATH/src/github.com/nabaz-io
-cd $GOPATH/github.com/nabaz-io
+cd $GOPATH/src/github.com/nabaz-io
 git clone https://github.com/nabaz-io/go
 cd go/src
 ./make.bash


### PR DESCRIPTION
I missed this in the earlier PR - I think that plus your previous change to remove `/bin/go` has got these steps correct now. Thanks!